### PR TITLE
Chore: repoint contributing links to .github/CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Closes #XXXXX
 
 ## Pull Request Requirements
 <!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
 -   [ ] The `Because` section summarizes the reason for this PR
 -   [ ] The `This PR` section has a bullet point list describing the changes in this PR

--- a/.github/issues/bug_report.md
+++ b/.github/issues/bug_report.md
@@ -10,7 +10,7 @@ assignees: ""
 
 Complete the following REQUIRED checkboxes:
 <!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this issue follows the `Bug: brief description of bug` format, e.g. `Bug: Lesson complete button does not update on click`
 
 The following checkbox is OPTIONAL:

--- a/.github/issues/feature_report.md
+++ b/.github/issues/feature_report.md
@@ -9,7 +9,7 @@ assignees: ""
 <!-- Thank you for taking the time to submit a new feature request to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the feature/enhancement you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
 Complete the following REQUIRED checkboxes:
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this issue follows the `location for request: brief description of request` format, e.g. `Foundations exercises: Add exercise for XYZ`
 
 The following checkbox is OPTIONAL:
@@ -19,8 +19,8 @@ The following checkbox is OPTIONAL:
 <hr>
 
 **1. Description of the Feature Request:**
-<!-- 
-A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve. 
+<!--
+A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve.
 -->
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository houses react examples which are uploaded to The Odin Project's C
 
 ## How To Add A React Example
 
-1. Read through the [contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md#curriculum-structure).
+1. Read through the [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md#curriculum-structure).
 2. Make sure you have node, npm and npx installed. You may use the [Installing Node.js](https://www.theodinproject.com/lessons/foundations-installing-node-js) lesson to install these tools.
 2. Fork & clone this repository. Install dependencies by running `npm install`.
 3. Create a new example folder by copying the `boilerplate` folder. And `cd` into it and install dependencies.
@@ -14,8 +14,8 @@ This repository houses react examples which are uploaded to The Odin Project's C
      npm install
    ```
 4. Code out your example.
-5. Start the dev server `npm run start` to make sure the example runs as expected. 
-6. Run `npm run lint` for ESLint and Prettier to format the code. 
+5. Start the dev server `npm run start` to make sure the example runs as expected.
+6. Run `npm run lint` for ESLint and Prettier to format the code.
 7. Create the pull request. (remember to mention which lesson will require the example)
 
 ### Naming examples
@@ -24,13 +24,13 @@ Make sure that examples are clearly named, meaning they should convey what the e
 
 ```c
 // bad
-example-1 
-state-example 
+example-1
+state-example
 arrays
 
 // good
 hello-world
-passing-props 
+passing-props
 rendering-arrays-in-jsx
 ```
 


### PR DESCRIPTION
## Because
- We are centralizing to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md as the single source of truth for CONTRIBUTING.md


## This PR
- Changes all https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md links to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md


## Issue

Part of TheOdinProject/theodinproject#3901

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section