### PR TITLE
Add Linux + macOS to devEngines restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,15 @@
     "globals": "^17.6.0",
     "prettier": "2.7.1",
     "vite": "^8.0.14"
+  },
+  "devEngines": {
+    "os": [
+      {
+        "name": "linux"
+      },
+      {
+        "name": "darwin"
+      }
+    ]
   }
 }


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This repo will run into issues that silently fail on Windows, which have been encountered by learners on more than one occasion. Since TOP does not support Windows, there is no need for us to ensure Windows support in this repo, even if the fix isn't complicated.

Instead, it'd make more sense to simply be upfront about not being compatible with Windows. If learners come to the community about it, they can be directed to our Installations lesson where we say many times that this is the case, and can then follow instructions to set up a supported environment.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds `devEngines` to enforce Linux or macOS

## Additional Information
Trying to set up on Linux:
<img width="468" height="209" alt="image" src="https://github.com/user-attachments/assets/7b834e18-f14b-4d4c-9c9c-128c2c517ea3" />

Same command on Windows:
<img width="640" height="250" alt="image" src="https://github.com/user-attachments/assets/a34a00c9-170a-4cc2-9f23-e7e88b322108" />
